### PR TITLE
fix: checks every volume mount instead of the first one

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -71,22 +71,29 @@ export async function checkAndResize() {
 					continue;
 				}
 
-				const container = pod.spec.containers.find(c => c.volumeMounts?.some(mount => mount.name === volume.name));
+				const mounts: { container: typeof pod.spec.containers[0]; mount: NonNullable<typeof pod.spec.containers[0]["volumeMounts"]>[0] }[] = [];
 
-				if (!container) {
+				for (const c of pod.spec.containers) {
+					const containerMounts = c.volumeMounts?.filter(m => m.name === volume.name) ?? [];
+					for (const m of containerMounts) {
+						mounts.push({ container: c, mount: m });
+					}
+				}
+
+				if (mounts.length === 0) {
 					continue;
 				}
 
-				if (!pod.status.containerStatuses?.find(status => status.name === container.name)?.ready) {
-					console.log(`  Pod ${pod.metadata.name} is not ready. Skipped.`);
+				const readyMount = mounts.find(({ container }) =>
+					pod.status.containerStatuses?.find(status => status.name === container.name)?.ready
+				);
+
+				if (!readyMount) {
+					console.log(`  Pod ${pod.metadata.name} has no ready container with this volume. Skipped.`);
 					continue;
 				}
 
-				const mount = container.volumeMounts?.find(m => m.name === volume.name);
-
-				if (!mount) {
-					continue;
-				}
+				const { container, mount } = readyMount;
 
 				let dfResult;
 
@@ -107,7 +114,7 @@ export async function checkAndResize() {
 				for (const dfLine of dfResult.split("\n")) {
 					const [_device, capacity, used, _free, _percent, mountPath] = dfLine.split(/\s+/u);
 
-					if (mountPath === mount.mountPath) {
+					if (mountPath && (mount.mountPath === mountPath || mount.mountPath.startsWith(mountPath + "/"))) {
 						const capacityBytes = parseInt(capacity, 10) * 1024;
 
 						usedBytes = parseInt(used, 10) * 1024;


### PR DESCRIPTION
**Descriping the changes:**
- Add a array of mounts then loop through all containers and all their volume mounts that match the volume name
- Skip if no mounts found
- Check all the mounts for ready containers instead of checkinh only one container mount
- If there are no ready containers then skip the resize check on this volume
- Finally, check if the mount path (possibly with subPath) starts with the mount path from the `df` output

**Summary:**
**All volumeMounts are checked:** Previously only the first container with a matching volume was checked. Now all containers and all their mounts for that volume are collected.

**subPath support:** The `df` matching now handles cases where a volume is mounted with a `subPath`, meaning the actual mount point in `df` output is a parent directory of the `mountPath` in the pod spec.